### PR TITLE
edition2018 and update winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mumble-link"
-version = "0.1.0"
+version = "0.2.0"
+edition = "2018"
 authors = ["Tad Hardesty <tad@platymuus.com>"]
 
 description = "Connector for Mumble Link positional audio"
@@ -13,8 +14,7 @@ documentation = "https://wombat.platymuus.com/rustdoc/mumble_link_0.1.0"
 
 [dependencies]
 libc = "0.2.16"
-winapi = "0.2.8"
-kernel32-sys = "0.2.2"
+winapi = { version = "0.3", features = ["memoryapi", "handleapi", "winnt"] }
 
 [dev-dependencies]
 time = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 //! Connect to Mumble link with `MumbleLink::new()`, set the context or player
 //! identity as needed, and call `update()` every frame with the position data.
 
-extern crate libc;
-
 use std::{io, ptr, mem};
 use libc::{c_float, wchar_t};
 
@@ -169,7 +167,7 @@ impl MumbleLink {
     /// conflict with this link. To avoid this, use `SharedLink`.
     pub fn new(name: &str, description: &str) -> io::Result<MumbleLink> {
         Ok(MumbleLink {
-            map: try!(imp::Map::new(std::mem::size_of::<LinkedMem>())),
+            map: (imp::Map::new(std::mem::size_of::<LinkedMem>()))?,
             local: LinkedMem::new(name, description),
         })
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,8 +1,6 @@
-extern crate kernel32;
-extern crate winapi;
-
 use std::io;
 use libc::{c_void, wchar_t};
+use winapi::um::{winnt, memoryapi, handleapi};
 
 pub fn copy(dest: &mut [wchar_t], src: &str) {
     if dest.is_empty() { return }
@@ -21,30 +19,30 @@ pub fn read(src: &[wchar_t]) -> String {
 }
 
 pub struct Map {
-    handle: winapi::HANDLE,
+    handle: winnt::HANDLE,
     pub ptr: *mut c_void,
 }
 
 impl Map {
     pub fn new(size: usize) -> io::Result<Map> {
         unsafe {
-            let handle = kernel32::OpenFileMappingW(
-                winapi::FILE_MAP_ALL_ACCESS,
-                winapi::FALSE,
+            let handle = memoryapi::OpenFileMappingW(
+                memoryapi::FILE_MAP_ALL_ACCESS,
+                winapi::shared::minwindef::FALSE,
                 wide!(M u m b l e L i n k).as_ptr(),
             );
             if handle.is_null() {
                 return Err(io::Error::last_os_error());
             }
-            let ptr = kernel32::MapViewOfFile(
+            let ptr = memoryapi::MapViewOfFile(
                 handle,
-                winapi::FILE_MAP_ALL_ACCESS,
+                memoryapi::FILE_MAP_ALL_ACCESS,
                 0,
                 0,
-                size as u64,
+                size,
             );
             if ptr.is_null() {
-                kernel32::CloseHandle(handle);
+                handleapi::CloseHandle(handle);
                 return Err(io::Error::last_os_error());
             }
             Ok(Map {
@@ -58,7 +56,7 @@ impl Map {
 impl Drop for Map {
     fn drop(&mut self) {
         unsafe {
-            kernel32::CloseHandle(self.handle);
+            handleapi::CloseHandle(self.handle);
         }
     }
 }


### PR DESCRIPTION
update to 2018 rust version and also to new winapi, with the new winapi 0.3 versions the usage of kernel32-sys is integrated so that crate is no longer needed